### PR TITLE
Amend perl's print equivalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ package main
 import "fmt"
 
 func main () {
-    fmt.Println("hello, world")
+    fmt.Print("hello, world")
 }
 ```
 


### PR DESCRIPTION
Go's `fmt.Println` adds a newline to the end of the string, so `fmt.Print`
is more correct equivalent for Perl's `print()`