### PR TITLE
Script run_go_fmt_for_code_in_readme.pl

### DIFF
--- a/run_go_fmt_for_code_in_readme.pl
+++ b/run_go_fmt_for_code_in_readme.pl
@@ -1,0 +1,129 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings FATAL => 'all';
+use feature 'say';
+use utf8;
+use open qw(:std :utf8);
+
+sub read_file {
+    my ($file_name) = @_;
+
+    open my $fh, '<', $file_name or die;
+    $/ = undef;
+    my $content = <$fh>;
+    close $fh;
+
+    return $content;
+}
+
+sub write_file {
+    my ($file_name, $content) = @_;
+
+    open my $fh, '>', $file_name or die;
+    print $fh $content;
+    close $fh;
+}
+
+sub run_go_fmt {
+    my ($code) = @_;
+
+    my $new_code;
+    my $err = 0;
+
+    write_file('a.go', $code);
+    my $result = `go fmt a.go 2>&1`;
+
+    if ($result =~ /^\s*\z/ || $result =~ '^\s*a.go\s*\z') {
+
+        # everything is fine
+        $new_code = read_file('a.go');
+
+    } else {
+        $new_code = '';
+        $err = 1;
+    }
+
+    unlink 'a.go';
+
+    return ($new_code, $err);
+}
+
+sub get_pretty_golang_code {
+    my ($code) = @_;
+
+    $code =~ s/^\s*//;
+    $code =~ s/\s*\z//;
+    $code = $code . "\n";
+
+    # At first trying to fmt code as-is
+    my ($pretty_code, $err) = run_go_fmt($code);
+    if (not $err) {
+        return $pretty_code;
+    }
+
+    # Next, trying to add 'package main'
+    ($pretty_code, $err) = run_go_fmt("package main\n" . $code);
+    if (not $err) {
+        $pretty_code =~ s/^package main\s*//;
+        return $pretty_code;
+    }
+
+    # Next, trying to put eveyrhing in main()
+    ($pretty_code, $err) = run_go_fmt("package main\nfunc main() {\n" . $code . "}\n");
+    if (not $err) {
+        $pretty_code =~ s/
+            ^
+            package\smain
+            \s+
+            func\smain\(\)\s\{
+            (.*)
+            \}
+        /
+        $1
+        /sx;
+
+        $pretty_code =~ s/^\t//msg;
+
+        $pretty_code =~ s/^\s*//;
+        $pretty_code =~ s/\s*\z//;
+        $pretty_code .= "\n";
+
+        return $pretty_code;
+    }
+
+    # If nothing worked just returning the original trimmed code
+    return $code;
+}
+
+sub main {
+
+    die "Can't run with file a.go in the current directory" if -e 'a.go';
+
+    my $content = read_file('README.md');
+    my $new_content = '';
+
+    my $golang_code = '';
+    my $is_in_golang_block = 0;
+
+    foreach my $line (split /\n/, $content) {
+
+        if ($line =~ /^```\s*/ && $is_in_golang_block) {
+            my $pretty_golang_code = get_pretty_golang_code($golang_code);
+            $new_content .= "```go\n$pretty_golang_code```\n";
+            $golang_code = '';
+            $is_in_golang_block = 0;
+        } elsif ($line =~ /^```go\s*/) {
+            $is_in_golang_block = 1;
+        } elsif ($is_in_golang_block) {
+            $golang_code .= $line . "\n";
+        } else {
+            $new_content .= $line . "\n";
+        }
+
+    }
+
+    write_file('README.md', $new_content);
+}
+main();
+__END__


### PR DESCRIPTION
There are some small indentation problems in the golang code. The most visible one is in the section "Deleting a Hash/Map Key":

![Screen Shot 2021-04-29 at 12 23 08](https://user-images.githubusercontent.com/47263/116529563-ca4db700-a8e5-11eb-867e-9523b43cccd1.png)

At first I just wanted to fix that, but then I've decided that it will be fun to prettify all golang code automatically. So I have written a small script that takes all golang code and tries to fix it with console `go fmt` tool.

In this PR there is only a script, I have not included the fixed version of README.md here.