### PR TITLE
Added examples for Perl using each and values, to supplement keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,7 +968,7 @@ func main() {
 
 #### Iterating Over a Hash/Map
 
-##### Perl
+##### Perl using keys
 
 ```perl
 my %hash = ( key_1 => 'foo', key_2 => 'bar', );
@@ -978,7 +978,7 @@ for my $key ( keys %hash ) {
 
 ```
 
-##### Go
+##### Go using only primary return value
 
 ```go
 package main
@@ -992,6 +992,62 @@ func main() {
 
 	for k := range myMap {
 		fmt.Printf("key: %s value: %s\n", k, myMap[k])
+	}
+}
+```
+
+##### Perl using each
+
+```perl
+my %hash = ( key_1 => 'foo', key_2 => 'bar', );
+for my $key, $value ( each %hash ) {
+    printf( "key: %s value: %s\n", $key, $value );
+}
+
+```
+
+##### Go using only primary and secondary return values
+
+```go
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	myMap := map[string]string{"key1": "foo", "key2": "bar"}
+
+	for _, v := range myMap {
+		fmt.Printf("key: %s value: %s\n", k, v)
+	}
+}
+```
+
+##### Perl using values
+
+```perl
+my %hash = ( key_1 => 'foo', key_2 => 'bar', );
+for my $key, $value ( values %hash ) {
+    printf( "key: %s value: %s\n", $key, $value );
+}
+
+```
+
+##### Go using ignoring primary return value, using only secondary return value
+
+```go
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	myMap := map[string]string{"key1": "foo", "key2": "bar"}
+
+	for _, v := range myMap {
+		fmt.Printf("value: %s\n", v)
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -996,6 +996,8 @@ func main() {
 }
 ```
 
+- [Go Playground](https://go.dev/play/p/qHcGFM1YRbF)
+
 ##### Perl using each
 
 ```perl
@@ -1024,6 +1026,8 @@ func main() {
 }
 ```
 
+- [Go Playground](https://go.dev/play/p/01_1pFznIHQ)
+
 ##### Perl using values
 
 ```perl
@@ -1031,7 +1035,6 @@ my %hash = ( key_1 => 'foo', key_2 => 'bar', );
 for my $value ( values %hash ) {
     printf( "value: %s\n", $value );
 }
-
 ```
 
 ##### Go using ignoring primary return value, using only secondary return value
@@ -1051,6 +1054,8 @@ func main() {
 	}
 }
 ```
+
+- [Go Playground](https://go.dev/play/p/UWqh6M4dGB6)
 
 #### Checking if a Hash/Map Key Exists
 

--- a/README.md
+++ b/README.md
@@ -1006,7 +1006,7 @@ for my $key, $value ( each %hash ) {
 
 ```
 
-##### Go using only primary and secondary return values
+##### Go using both primary and secondary return values
 
 ```go
 package main
@@ -1018,7 +1018,7 @@ import (
 func main() {
 	myMap := map[string]string{"key1": "foo", "key2": "bar"}
 
-	for _, v := range myMap {
+	for k, v := range myMap {
 		fmt.Printf("key: %s value: %s\n", k, v)
 	}
 }
@@ -1028,8 +1028,8 @@ func main() {
 
 ```perl
 my %hash = ( key_1 => 'foo', key_2 => 'bar', );
-for my $key, $value ( values %hash ) {
-    printf( "key: %s value: %s\n", $key, $value );
+for my $value ( values %hash ) {
+    printf( "value: %s\n", $value );
 }
 
 ```


### PR DESCRIPTION
Hi @oalders 

My go-to guide [yourbasic.org/golang](https://yourbasic.org/golang/) does not hold examples on how to [sort values](https://yourbasic.org/golang/sort-map-keys-values/) even though it sort of stated so.

I consulted your marvelous guide and I saw that it perhaps  could benefit from some more `map`/`hash` examples.

I do break convention a bit with the proposed titles, but since these are variations of the same recipes it might be necessary to provide more details for the TOC etc.

So this is a first shot, I hope you find it useful if not, just ditch it.

jonasbn